### PR TITLE
added ubuntu 24 support

### DIFF
--- a/vars/ubuntu-24.yml
+++ b/vars/ubuntu-24.yml
@@ -1,0 +1,21 @@
+---
+mariadb_login_unix_socket: "/var/run/mysqld/mysqld.sock"
+mariadb_pre_req_packages:
+  - "apt-transport-https"
+  - "software-properties-common"
+  - "python3-pymysql"
+  - "rsync"
+mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
+mariadb_packages:
+  - "mariadb-server"
+mariabackup_packages:
+  - "mariadb-backup"
+mariadb_certificates_dir: "/etc/mysql/certificates"
+mariadb_systemd_service_name: "mariadb.service"
+mariadb_confs:
+  - name: "etc/mysql/debian.cnf"
+  - name: "etc/mysql/my.cnf"
+  - name: "etc/mysql/conf.d/galera.cnf"
+mariadb_temp_confs:
+  - "etc/mysql/conf.d/galera.cnf"
+galera_wsrep_provider: "/usr/lib/galera/libgalera_smm.so"


### PR DESCRIPTION
Installation on Ubuntu 24.04 & 24.11 fails due to the inheritance of debian.yml, where python-pymsql will be installed, which only exists in Debian 10.

This PR fixes [#239]